### PR TITLE
Add admin and user masters with Inertia pages

### DIFF
--- a/src/portfolio/app/Http/Controllers/AdminController.php
+++ b/src/portfolio/app/Http/Controllers/AdminController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Admin;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class AdminController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('Admin/Index', [
+            'admins' => Admin::all(),
+        ]);
+    }
+
+    public function create()
+    {
+        return Inertia::render('Admin/Create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:admins,email',
+            'password' => 'required|string|min:8',
+        ]);
+
+        Admin::create($data);
+
+        return redirect()->route('admins.index');
+    }
+}

--- a/src/portfolio/app/Http/Controllers/UserController.php
+++ b/src/portfolio/app/Http/Controllers/UserController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        return Inertia::render('User/Index', [
+            'users' => User::all(),
+        ]);
+    }
+
+    public function create()
+    {
+        return Inertia::render('User/Create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'required|string|min:8',
+        ]);
+
+        User::create($data);
+
+        return redirect()->route('users.index');
+    }
+}

--- a/src/portfolio/app/Models/Admin.php
+++ b/src/portfolio/app/Models/Admin.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Admin extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    protected $hidden = [
+        'password',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'password' => 'hashed',
+        ];
+    }
+}

--- a/src/portfolio/database/migrations/0001_01_01_000003_create_admins_table.php
+++ b/src/portfolio/database/migrations/0001_01_01_000003_create_admins_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('admins');
+    }
+};

--- a/src/portfolio/resources/js/Pages/Admin/Create.jsx
+++ b/src/portfolio/resources/js/Pages/Admin/Create.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Head, router } from '@inertiajs/react';
+import { Container, Typography, TextField, Button, Box } from '@mui/material';
+
+export default function Create() {
+    const [values, setValues] = useState({ name: '', email: '', password: '' });
+
+    const handleChange = e => {
+        setValues({ ...values, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = e => {
+        e.preventDefault();
+        router.post('/admins', values);
+    };
+
+    return (
+        <Container sx={{ py: 4 }}>
+            <Head title="Create Admin" />
+            <Typography variant="h4" gutterBottom>
+                Create Admin
+            </Typography>
+            <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField name="name" value={values.name} onChange={handleChange} label="Name" />
+                <TextField name="email" value={values.email} onChange={handleChange} label="Email" />
+                <TextField type="password" name="password" value={values.password} onChange={handleChange} label="Password" />
+                <Button type="submit" variant="contained">
+                    Save
+                </Button>
+            </Box>
+        </Container>
+    );
+}

--- a/src/portfolio/resources/js/Pages/Admin/Index.jsx
+++ b/src/portfolio/resources/js/Pages/Admin/Index.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link, Head } from '@inertiajs/react';
+import {
+    Container,
+    Typography,
+    Button,
+    List,
+    ListItem,
+} from '@mui/material';
+
+export default function Index({ admins }) {
+    return (
+        <Container sx={{ py: 4 }}>
+            <Head title="Admins" />
+            <Typography variant="h4" gutterBottom>
+                Admins
+            </Typography>
+            <Button
+                component={Link}
+                href="/admins/create"
+                variant="contained"
+                sx={{ mb: 2 }}
+            >
+                Create Admin
+            </Button>
+            <List>
+                {admins.map((admin) => (
+                    <ListItem key={admin.id}>
+                        {admin.name} ({admin.email})
+                    </ListItem>
+                ))}
+            </List>
+        </Container>
+    );
+}

--- a/src/portfolio/resources/js/Pages/User/Create.jsx
+++ b/src/portfolio/resources/js/Pages/User/Create.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { Head, router } from '@inertiajs/react';
+import { Container, Typography, TextField, Button, Box } from '@mui/material';
+
+export default function Create() {
+    const [values, setValues] = useState({ name: '', email: '', password: '' });
+
+    const handleChange = e => {
+        setValues({ ...values, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = e => {
+        e.preventDefault();
+        router.post('/users', values);
+    };
+
+    return (
+        <Container sx={{ py: 4 }}>
+            <Head title="Create User" />
+            <Typography variant="h4" gutterBottom>
+                Create User
+            </Typography>
+            <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField name="name" value={values.name} onChange={handleChange} label="Name" />
+                <TextField name="email" value={values.email} onChange={handleChange} label="Email" />
+                <TextField type="password" name="password" value={values.password} onChange={handleChange} label="Password" />
+                <Button type="submit" variant="contained">
+                    Save
+                </Button>
+            </Box>
+        </Container>
+    );
+}

--- a/src/portfolio/resources/js/Pages/User/Index.jsx
+++ b/src/portfolio/resources/js/Pages/User/Index.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link, Head } from '@inertiajs/react';
+import {
+    Container,
+    Typography,
+    Button,
+    List,
+    ListItem,
+} from '@mui/material';
+
+export default function Index({ users }) {
+    return (
+        <Container sx={{ py: 4 }}>
+            <Head title="Users" />
+            <Typography variant="h4" gutterBottom>
+                Users
+            </Typography>
+            <Button
+                component={Link}
+                href="/users/create"
+                variant="contained"
+                sx={{ mb: 2 }}
+            >
+                Create User
+            </Button>
+            <List>
+                {users.map((user) => (
+                    <ListItem key={user.id}>
+                        {user.name} ({user.email})
+                    </ListItem>
+                ))}
+            </List>
+        </Container>
+    );
+}

--- a/src/portfolio/routes/web.php
+++ b/src/portfolio/routes/web.php
@@ -2,7 +2,12 @@
 
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use App\Http\Controllers\AdminController;
+use App\Http\Controllers\UserController;
 
 Route::get('/', function () {
     return Inertia::render('Welcome');
 });
+
+Route::resource('admins', AdminController::class)->only(['index', 'create', 'store']);
+Route::resource('users', UserController::class)->only(['index', 'create', 'store']);


### PR DESCRIPTION
## Summary
- add Admin model, migration, and controller
- add User controller and Inertia pages for admin and user management
- register routes for admin and user resources
- replace Tailwind markup in Inertia pages with Material UI components

## Testing
- `npm run build`
- `php artisan test` *(fails: Failed to open required vendor/autoload.php; Composer install requires GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a442af5158832bb71b6c7de1620b12