### PR TITLE
Add todo management scaffolding

### DIFF
--- a/src/portfolio/app/Http/Controllers/Admin/AdminController.php
+++ b/src/portfolio/app/Http/Controllers/Admin/AdminController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Admin;
+use Illuminate\Http\Request;
+
+class AdminController extends Controller
+{
+    /**
+     * Show the login form.
+     */
+    public function login()
+    {
+        return response()->json(['message' => 'login form']);
+    }
+
+    /**
+     * Handle an authentication attempt.
+     */
+    public function authenticate(Request $request)
+    {
+        // Authentication logic placeholder
+        return response()->json(['message' => 'authenticated']);
+    }
+
+    /**
+     * Display a listing of admins.
+     */
+    public function index()
+    {
+        return response()->json(Admin::all());
+    }
+
+    /**
+     * Store a newly created admin in storage.
+     */
+    public function store(Request $request)
+    {
+        $admin = Admin::create($request->all());
+        return response()->json($admin, 201);
+    }
+
+    /**
+     * Update the specified admin in storage.
+     */
+    public function update(Request $request, Admin $admin)
+    {
+        $admin->update($request->all());
+        return response()->json($admin);
+    }
+
+    /**
+     * Remove the specified admin from storage.
+     */
+    public function destroy(Admin $admin)
+    {
+        $admin->delete();
+        return response()->json();
+    }
+}

--- a/src/portfolio/app/Http/Controllers/Admin/TodoController.php
+++ b/src/portfolio/app/Http/Controllers/Admin/TodoController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Todo;
+use Illuminate\Http\Request;
+
+class TodoController extends Controller
+{
+    /**
+     * Display a listing of todos.
+     */
+    public function index()
+    {
+        return response()->json(Todo::with('user')->get());
+    }
+
+    /**
+     * Store a newly created todo in storage.
+     */
+    public function store(Request $request)
+    {
+        $todo = Todo::create($request->all());
+        return response()->json($todo, 201);
+    }
+
+    /**
+     * Update the specified todo in storage.
+     */
+    public function update(Request $request, Todo $todo)
+    {
+        $todo->update($request->all());
+        return response()->json($todo);
+    }
+
+    /**
+     * Remove the specified todo from storage.
+     */
+    public function destroy(Todo $todo)
+    {
+        $todo->delete();
+        return response()->json();
+    }
+}

--- a/src/portfolio/app/Http/Controllers/Admin/UserController.php
+++ b/src/portfolio/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    /**
+     * Display a listing of users.
+     */
+    public function index()
+    {
+        return response()->json(User::all());
+    }
+
+    /**
+     * Store a newly created user in storage.
+     */
+    public function store(Request $request)
+    {
+        $user = User::create($request->all());
+        return response()->json($user, 201);
+    }
+
+    /**
+     * Update the specified user in storage.
+     */
+    public function update(Request $request, User $user)
+    {
+        $user->update($request->all());
+        return response()->json($user);
+    }
+
+    /**
+     * Remove the specified user from storage.
+     */
+    public function destroy(User $user)
+    {
+        $user->delete();
+        return response()->json();
+    }
+}

--- a/src/portfolio/app/Http/Controllers/TodoController.php
+++ b/src/portfolio/app/Http/Controllers/TodoController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Todo;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TodoController extends Controller
+{
+    /**
+     * Display a listing of the user's todos.
+     */
+    public function index()
+    {
+        $todos = Todo::where('user_id', Auth::id())
+            ->orderByRaw("FIELD(priority, 'high', 'medium', 'low')")
+            ->orderBy('due_date')
+            ->get();
+
+        return response()->json($todos);
+    }
+
+    /**
+     * Store a newly created todo in storage.
+     */
+    public function store(Request $request)
+    {
+        $todo = Todo::create([
+            'user_id' => Auth::id(),
+            'task_name' => $request->input('task_name'),
+            'due_date' => $request->input('due_date'),
+            'priority' => $request->input('priority', 'low'),
+        ]);
+
+        return response()->json($todo, 201);
+    }
+
+    /**
+     * Mark the specified todo as complete.
+     */
+    public function complete(Todo $todo)
+    {
+        if ($todo->user_id !== Auth::id()) {
+            abort(403);
+        }
+
+        $todo->update(['is_complete' => true]);
+        return response()->json($todo);
+    }
+}

--- a/src/portfolio/app/Models/Admin.php
+++ b/src/portfolio/app/Models/Admin.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class Admin extends Authenticatable
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+}

--- a/src/portfolio/app/Models/Todo.php
+++ b/src/portfolio/app/Models/Todo.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Todo extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'task_name',
+        'due_date',
+        'priority',
+        'is_complete',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'due_date' => 'date',
+            'is_complete' => 'boolean',
+        ];
+    }
+
+    /**
+     * Get the owning user.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/src/portfolio/app/Models/User.php
+++ b/src/portfolio/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use App\Models\Todo;
 
 class User extends Authenticatable
 {
@@ -44,5 +45,13 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Get the todos for the user.
+     */
+    public function todos()
+    {
+        return $this->hasMany(Todo::class);
     }
 }

--- a/src/portfolio/bootstrap/app.php
+++ b/src/portfolio/bootstrap/app.php
@@ -6,7 +6,10 @@ use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
-        web: __DIR__.'/../routes/web.php',
+        web: [
+            __DIR__.'/../routes/web.php',
+            __DIR__.'/../routes/admin.php',
+        ],
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/src/portfolio/database/migrations/0001_01_01_000003_create_admins_table.php
+++ b/src/portfolio/database/migrations/0001_01_01_000003_create_admins_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('admins', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('admins');
+    }
+};

--- a/src/portfolio/database/migrations/0001_01_01_000004_create_todos_table.php
+++ b/src/portfolio/database/migrations/0001_01_01_000004_create_todos_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('todos', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('task_name');
+            $table->date('due_date');
+            $table->enum('priority', ['high', 'medium', 'low'])->default('low');
+            $table->boolean('is_complete')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('todos');
+    }
+};

--- a/src/portfolio/routes/admin.php
+++ b/src/portfolio/routes/admin.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\AdminController;
+use App\Http\Controllers\Admin\UserController;
+use App\Http\Controllers\Admin\TodoController;
+
+Route::prefix('admin')->name('admin.')->group(function () {
+    Route::get('login', [AdminController::class, 'login'])->name('login');
+    Route::post('login', [AdminController::class, 'authenticate'])->name('authenticate');
+
+    Route::middleware('auth:admin')->group(function () {
+        Route::resource('admins', AdminController::class)->except(['show', 'create', 'edit']);
+        Route::resource('users', UserController::class)->except(['show', 'create', 'edit']);
+        Route::resource('todos', TodoController::class)->except(['show', 'create', 'edit']);
+    });
+});

--- a/src/portfolio/routes/web.php
+++ b/src/portfolio/routes/web.php
@@ -2,7 +2,14 @@
 
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use App\Http\Controllers\TodoController;
 
 Route::get('/', function () {
     return Inertia::render('Welcome');
+});
+
+Route::middleware('auth')->group(function () {
+    Route::get('/todos', [TodoController::class, 'index'])->name('todos.index');
+    Route::post('/todos', [TodoController::class, 'store'])->name('todos.store');
+    Route::patch('/todos/{todo}/complete', [TodoController::class, 'complete'])->name('todos.complete');
 });


### PR DESCRIPTION
## Summary
- scaffold admins and todos tables for management
- add models and controllers for admin/user todo flows
- split admin routes and load via bootstrap configuration

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `composer test` *(fails: @php artisan config:clear --ansi handling the test event returned with error code 255)*

------
https://chatgpt.com/codex/tasks/task_e_68a44e1dc46c832b95edd0b1808e4441